### PR TITLE
Upgrade Salt Deps for Monitoring

### DIFF
--- a/requirements/deepfield.txt
+++ b/requirements/deepfield.txt
@@ -1,4 +1,6 @@
-pyinotify ==0.9.6
-psycopg2 ==2.9.7
+boto3 ==1.35.77
 GitPython ==3.1.37
+keeper-secrets-manager-core ==16.6.6
+psycopg2 ==2.9.7
+pyinotify ==0.9.6
 redis ==5.0.1


### PR DESCRIPTION
Adds Boto3 to Salt for Monitoring, Also adds Keeper Secrets Manager so we can migrate off of Boto in the future.