### PR TITLE
SYS-7755: add MAINTAIN privilege to _PRIVILEGES_MAP for PostgreSQL 17

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -96,6 +96,7 @@ _PRIVILEGES_MAP = {
     "X": "EXECUTE",
     "x": "REFERENCES",
     "d": "DELETE",
+    "m": "MAINTAIN",
     "*": "GRANT",
 }
 _PRIVILEGES_OBJECTS = frozenset(


### PR DESCRIPTION
https://deepfield.atlassian.net/browse/SYS-7755
Adds a new key for new maintain privilege of PostgreSQL 17, in  _PRIVILEGES_MAP
Right now Salt 3006.23+1.df throws an exception. We are patching this to a new 3006.23+2.df Salt